### PR TITLE
Update Slack announcement version

### DIFF
--- a/bin/announce
+++ b/bin/announce
@@ -2,13 +2,20 @@
 
 set -eux
 
+PACKAGE_VERSION=$(cat package.json \
+  | grep version \
+  | head -1 \
+  | awk -F: '{ print $2 }' \
+  | sed 's/[",]//g' \
+  | tr -d '[[:space:]]')
+
 curl \
 ${SLACK_WEBHOOK_URL} \
 -X POST \
 -H 'Content-Type: application/json' \
 -d @/dev/stdin <<JSON
 {
-  "text": "PS Components version ${BUILDKITE_MESSAGE} released :tada:",
+  "text": "PS Components version ${PACKAGE_VERSION} released :tada:",
   "channel": "#profs-dev",
   "username": "PS Components",
   "icon_emoji": ":${SLACK_ANNOUNCE_EMOJI}:"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps-components",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Update Slack announcement version to come from package.json instead of commit message!

<img width="293" alt="screen shot 2017-01-17 at 10 04 26 am" src="https://cloud.githubusercontent.com/assets/729085/22003039/59ab2f42-dc9c-11e6-932b-fb4c3c6b5a20.png">

Closes #8 