### PR TITLE
Leaderboard item image, and consistent li indent

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ps-components",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Library of re-usable components for Professional Services projects",
   "main": "index.js",
   "scripts": {

--- a/source/components/LeaderboardItem/styles.js
+++ b/source/components/LeaderboardItem/styles.js
@@ -41,6 +41,7 @@ export default (props, traits) => {
     },
 
     image: {
+      flexShrink: 0,
       width: rhythm(1.25),
       height: rhythm(1.25),
       backgroundColor: 'rgba(0,0,0,0.125)',

--- a/source/components/LeaderboardItem/styles.js
+++ b/source/components/LeaderboardItem/styles.js
@@ -41,7 +41,7 @@ export default (props, traits) => {
     },
 
     image: {
-      flexShrink: 0,
+      flex: '0 0 auto',
       width: rhythm(1.25),
       height: rhythm(1.25),
       backgroundColor: 'rgba(0,0,0,0.125)',

--- a/source/components/RichText/Readme.md
+++ b/source/components/RichText/Readme.md
@@ -16,9 +16,9 @@ Provides a standard format for chunks of markup
   <h4>Heading 4</h4>
   <p>Donec id elit non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas sed diam eget risus varius blandit sit amet non magna. Etiam porta sem malesuada magna mollis euismod.</p>
   <ul>
-    <li>List item 1</li>
-    <li>List item 2</li>
-    <li>List item 3</li>
+    <li>Donec id elit non mi porta gravida at eget metus. Etiam porta sem malesuada magna mollis euismod. Vestibulum id ligula porta felis euismod semper.</li>
+    <li>Donec id elit non mi porta gravida at eget metus. Etiam porta sem malesuada magna mollis euismod. Vestibulum id ligula porta felis euismod semper.</li>
+    <li>Donec id elit non mi porta gravida at eget metus. Etiam porta sem malesuada magna mollis euismod. Vestibulum id ligula porta felis euismod semper.</li>
   </ul>
   <h5>Heading 5</h5>
   <p>Donec id elit non mi porta gravida at eget metus. Vivamus sagittis lacus vel augue laoreet rutrum faucibus dolor auctor. Maecenas sed diam eget risus varius blandit sit amet non magna. Etiam porta sem malesuada magna mollis euismod.</p>

--- a/source/components/RichText/styles.js
+++ b/source/components/RichText/styles.js
@@ -24,16 +24,20 @@ export default (props, traits) => {
 
     ul: {
       listStyleType: 'disc',
-      listStylePosition: 'inside',
+      listStylePosition: 'outside',
       paddingBottom: rhythm(1),
       lineHeight: measures.medium
     },
 
     ol: {
       listStyleType: 'decimal',
-      listStylePosition: 'inside',
+      listStylePosition: 'outside',
       paddingBottom: rhythm(1),
       lineHeight: measures.medium
+    },
+
+    li: {
+      marginLeft: rhythm(1)
     },
 
     blockquote: {


### PR DESCRIPTION
Working on the Gub project, just came across a couple of small niggly things that I wanted to touch up...

1) Leaderboard item images were shirking when there wasn't much width to play with, meaning they became ovals

2) Default list item content was wrapping down under the bullet if it wrapped onto a second line, so just wanted to make that space consistent